### PR TITLE
27 feat add finding severity (closes #27)

### DIFF
--- a/swagtag/annotation/io.py
+++ b/swagtag/annotation/io.py
@@ -44,5 +44,6 @@ def load_annotations(study_instance_uid: str,
         ids_to_load=[study_instance_uid],
         conn=conn,
     )
+    print(annotations)
 
     return {annotation[sql_conf['result_table']['prim_key']]: annotation for annotation in annotations}

--- a/swagtag/config/config.yaml
+++ b/swagtag/config/config.yaml
@@ -58,6 +58,13 @@ dashboard:
     - 'hiatal hernia'
     - 'fibrosis'
     - 'emphysema'
+  annotation_attributes:
+    - 'probability'
+    - 'severity'
+    - 'urgency'
+    - 'side'
+    - 'left_height'
+    - 'right_height'
   annotation_probability:
     {
       0: 'absent',
@@ -94,7 +101,8 @@ dashboard:
   default_annotation_severity: 0
   default_annotation_urgency: 0
   default_annotation_side: 0
-  default_annotation_height: [ ]
+  default_annotation_left_height: [ ]
+  default_annotation_right_height: [ ]
 
 
 sql:
@@ -185,6 +193,7 @@ sql:
           'AccessionNumber': 'character varying(256)',
           'annotation_json': 'jsonb',
           'creation_time': 'timestamp',
+          'author': 'character varying(256)',
         },
       prim_key: 'annotation_id',
       timestamp_col: 'creation_time',

--- a/swagtag/st_utils/st_annotation.py
+++ b/swagtag/st_utils/st_annotation.py
@@ -90,6 +90,8 @@ def st_annotation_box():
                         )
                     case 3:  # both
                         st.markdown("#### Right")
+                        print(list(st.session_state.dash_conf['annotation_height'].keys()))
+                        print(st.session_state.current_annotation[tag]['right_height'])
                         st.multiselect(
                             label='Vertical location',
                             default=st.session_state.current_annotation[tag]['right_height'],


### PR DESCRIPTION
This PR adds support for separating a `severity` and an `urgency` attribute to annotated tags.

Under the hood some handling of default tags has been updated/generalized.

By default we now load the config from the `config.yaml` file. If wished by a user she can still store and load the configuration (including current case) using the io functions in the sidebar.